### PR TITLE
[defect][4] Fix logo not showing when deployed

### DIFF
--- a/EITParcelDelivery/EITParcelDelivery.csproj
+++ b/EITParcelDelivery/EITParcelDelivery.csproj
@@ -205,6 +205,7 @@
     <Content Include="Content\bootstrap-theme.min.css" />
     <Content Include="Content\bootstrap.css" />
     <Content Include="Content\bootstrap.min.css" />
+    <Content Include="Content\Images\eit-logo.png" />
     <Content Include="Database\EITDB.Context.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <DependentUpon>EITDB.edmx</DependentUpon>
@@ -260,7 +261,6 @@
   <ItemGroup>
     <Folder Include="App_Code\" />
     <Folder Include="App_Data\" />
-    <Folder Include="Content\Images\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="fonts\glyphicons-halflings-regular.woff2" />


### PR DESCRIPTION
EIT logo was not included when deploying the solution.
This PR adds the resource to the manifest file so it's correctly included.